### PR TITLE
#10 Implement entries method

### DIFF
--- a/doc/arr.md
+++ b/doc/arr.md
@@ -289,3 +289,33 @@ $onlyFruits = $fruits->values();
  */
 ```
 
+## Extract entries
+The *entries()* method returns a new Arr object that contains the key/value pairs for each index in the array.
+
+```php
+use HiFolks\DataType\Arr;
+$fruits = Arr::make([
+    7 => '🥝',
+    -1 => '🍓',
+    1 => '🍋',
+    'mango' => '🥭',
+    'apple' => '🍎',
+    'banana' => '🍌',
+    '🍊',
+    '🍍', ]);
+$entries = $fruits->entries();
+var_dump($entries->arr());
+/*
+[
+    [7, '🥝'],
+    [-1, '🍓'],
+    [1, '🍋'],
+    ['mango', '🥭'],
+    ['apple', '🍎'],
+    ['banana', '🍌'],
+    [8, '🍊'],
+    [9, '🍍']
+]
+*/
+```
+

--- a/examples/cheatsheet.php
+++ b/examples/cheatsheet.php
@@ -190,6 +190,18 @@ print_result($arr->includes('2'));
 print_result($arr->includes(3, 3));
 print_result($arr->includes(3, 2));
 
+// Extract entries with entries()
+$fruits = Arr::make([
+    'kiwi' => '🥝',
+    'fragola' => '🍓',
+    'lemon' => '🍋',
+    'mango' => '🥭',
+    'apple' => '🍎',
+    'banana' => '🍌', ]);
+// entries as array
+$entries = $fruits->entries();
+print_result($entries);
+
 /**
  * Print a line for string, integer, array, boolean.
  */

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -642,4 +642,17 @@ class Arr implements Iterator, ArrayAccess
     {
         return new self(array_values($this->arr));
     }
+
+    /**
+     * @return Arr object that contains the key/value pairs for each index in the array
+     */
+    public function entries(): self
+    {
+        $pairs = [];
+        foreach ($this->arr as $k => $v) {
+            $pairs[] = [$k, $v];
+        }
+
+        return self::make($pairs);
+    }
 }

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -498,7 +498,8 @@ it('creates entries', function () {
         'apple' => '🍎',
         'banana' => '🍌',
         '🍊',
-        '🍍', ]);
+        '🍍',
+    ]);
 
     $entries = $fruits->entries();
     expect($entries->arr())->toBeArray();

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -488,3 +488,29 @@ it(' extract values', function () {
     expect($onlyFruits[3])->toEqual('🥭');
     expect($onlyFruits[7])->toEqual('🍍');
 });
+
+it('creates entries', function () {
+    $fruits = Arr::make([
+        7 => '🥝',
+        -1 => '🍓',
+        1 => '🍋',
+        'mango' => '🥭',
+        'apple' => '🍎',
+        'banana' => '🍌',
+        '🍊',
+        '🍍', ]);
+
+    $entries = $fruits->entries();
+    expect($entries->arr())->toBeArray();
+    expect($entries->length())->toEqual(8);
+    expect($entries)->toEqual(Arr::make([
+        [7, '🥝'],
+        [-1, '🍓'],
+        [1, '🍋'],
+        ['mango', '🥭'],
+        ['apple', '🍎'],
+        ['banana', '🍌'],
+        [8, '🍊'],
+        [9, '🍍'],
+    ]));
+});


### PR DESCRIPTION
This solves #10 

I could think of change the behaviour of `entries` to returning a nested `Arr` object instead of returning an `Arr` object with arrays in it. But I'm not sure, if this would be somehow practical. The expectation in the test would be then

```php
expect($entries)->toEqual(Arr::make([
        Arr::make([7, '🥝']),
        Arr::make([-1, '🍓']),
        Arr:make([1, '🍋']),
        ...
    ]));
```

What do you think about it?