### PR TITLE
Implement copyWithin array function

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The Arr class provides some methods:
 - from(): for creating new Arr from a string or array-like object;
 - findIndex(): for finding the index of some element;
 - entries(): eturns a new Arr object that contains the key/value pairs for each index in the array.
+- copyWithin(): copies part of the array to a location but keeps the original length.
 
 
 ## Table class

--- a/doc/arr.md
+++ b/doc/arr.md
@@ -361,3 +361,26 @@ var_dump($arr->find(fn ($element) => str_contains($element, 'es')));
 // 'test'
 ```
 
+## Shadow copy part of the array to another location and keep the length
+
+```php
+use HiFolks\DataType\Arr;
+
+$arr = Arr::make([1, 2, 3, 4, 5]);
+var_dump($arr->copyWithin(-2));
+// [1, 2, 3, 1, 2]
+
+$arr = Arr::make([1, 2, 3, 4, 5]);
+var_dump($arr->copyWithin(0, 3));
+// [4, 5, 3, 4, 5]
+
+$arr = Arr::make([1, 2, 3, 4, 5]);
+var_dump($arr->copyWithin(0, 3, 4));
+// [4, 2, 3, 4, 5]
+
+$arr = Arr::make([1, 2, 3, 4, 5]);
+var_dump($arr->copyWithin(-2, -3, -1));
+// [1, 2, 3, 3, 4]
+
+```
+

--- a/examples/cheatsheet.php
+++ b/examples/cheatsheet.php
@@ -256,4 +256,18 @@ function print_result(mixed $something): void
     $arr = Arr::make(['foo', 'bar', 'baz']);
     print_result($arr->find(fn ($element) => str_contains($element, 'a')));
     // 'bar'
+
+    // Returns the shadow copied part of the array to another location and keeps its length
+    $arr = Arr::make([1, 2, 3, 4, 5]);
+    print_result($arr->copyWithin(-2));
+    // [1, 2, 3, 1, 2]
+    $arr = Arr::make([1, 2, 3, 4, 5]);
+    print_result($arr->copyWithin(0, 3));
+    // [4, 5, 3, 4, 5]
+    $arr = Arr::make([1, 2, 3, 4, 5]);
+    print_result($arr->copyWithin(0, 3, 4));
+    // [4, 2, 3, 4, 5]
+    $arr = Arr::make([1, 2, 3, 4, 5]);
+    print_result($arr->copyWithin(-2, -3, -1));
+    // [1, 2, 3, 3, 4]
 }

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -688,4 +688,25 @@ class Arr implements Iterator, ArrayAccess
 
         return null;
     }
+
+    /**
+     * The copyWithin() method shallow copies part of an array to another location in the same array and returns it without modifying its length.
+     * @return array
+     */
+    public function copyWithin(int $target, int $start = 0, int $end = null): array
+    {
+        $arrayLength = $this->length();
+        $chuck = $this->slice($start, $end);
+        if ($target < 0) {
+            $target = $arrayLength - (int) abs($target);
+        }
+
+        foreach ($chuck as $value) {
+            $this->arr[$target] = $value;
+            $target++;
+        }
+
+        $this->arr = $this->slice(0, $arrayLength)->arr;
+        return $this->arr;
+    }
 }

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -553,3 +553,43 @@ it('creates entries', function () {
         [9, '🍍'],
     ]));
 });
+
+it('tests copyWithin() method with one parameter', function () {
+    $arr = Arr::make([1, 2, 3, 4, 5]);
+
+    $result = $arr->copyWithin(-2);
+    expect($result)
+        ->toBeArray()
+//        ->toHaveCount(5)
+        ->toEqual([1, 2, 3, 1, 2]);
+});
+
+it('tests copyWithin() method with two parameters', function () {
+    $arr = Arr::make([1, 2, 3, 4, 5]);
+
+    $result = $arr->copyWithin(0, 3);
+    expect($result)
+        ->toBeArray()
+        ->toHaveCount(5)
+        ->toEqual([4, 5, 3, 4, 5]);
+});
+
+it('tests copyWithin() method with all the parameters', function () {
+    $arr = Arr::make([1, 2, 3, 4, 5]);
+
+    $result = $arr->copyWithin(0, 3, 4);
+    expect($result)
+        ->toBeArray()
+        ->toHaveCount(5)
+        ->toEqual([4, 2, 3, 4, 5]);
+});
+
+it('tests copyWithin() method with all the parameters negative', function () {
+    $arr = Arr::make([1, 2, 3, 4, 5]);
+
+    $result = $arr->copyWithin(-2, -3, -1);
+    expect($result)
+        ->toBeArray()
+        ->toHaveCount(5)
+        ->toEqual([1, 2, 3, 3, 4]);
+});


### PR DESCRIPTION
This function as been introduced due to #9

The functionality is the same as the JavaScript method where the 2nd and 3rd parameters are optional.
The method can also take negative numbers.

After doing some testing to ensure that the functionality works the same as the JavaScript version. The function returns the new array but also changes the original version of the array within the `Arr` object.