### PR TITLE
Allow flatMap to support multidimensional arrays

### DIFF
--- a/src/Arr.php
+++ b/src/Arr.php
@@ -225,9 +225,9 @@ class Arr implements Iterator, ArrayAccess
     /**
      * Add an $element to the end of an array and returns new length
      */
-    public function push($element): int
+    public function push(...$element): int
     {
-        return array_push($this->arr, $element);
+        return array_push($this->arr, ...$element);
     }
 
     /**
@@ -489,17 +489,26 @@ class Arr implements Iterator, ArrayAccess
      */
     public function flatMap(callable $callback): self
     {
-        $array = [];
+        $array = Arr::make([]);
+
         foreach ($this->arr as $key => $element) {
+            if (is_array($element)) {
+                $array->push(...self::make($element)
+                    ->forEach($callback)
+                    ->arr());
+                continue;
+            }
+
             $a = $callback($element, $key);
+
             if (is_array($a)) {
-                $array = array_merge($array, [...$a]);
+                $array->push(...$a);
             } else {
-                $array[] = $a;
+                $array->push($a);
             }
         }
 
-        return self::make($array);
+        return $array;
     }
 
     /**

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -320,9 +320,12 @@ it('flats and maps array', function () {
     $arr2 = $arr->flatMap(fn ($element) => [$element, $element * 2]);
     expect($arr->length())->toEqual(7);
     expect($arr2->length())->toEqual(14);
+    expect($arr2->arr())->toEqual([1, 2, 2, 4, 3, 6, 4, 8, 5, 10, 6, 12, 7, 14]);
+
     $arr2 = $arr->flatMap(fn ($element) => $element);
     expect($arr->length())->toEqual(7);
     expect($arr2->length())->toEqual(7);
+    expect($arr2->arr())->toEqual([1, 2, 3, 4, 5, 6, 7]);
 });
 
 it('fills array', function () {
@@ -567,7 +570,7 @@ it('tests copyWithin() method with one parameter', function () {
     $result = $arr->copyWithin(-2);
     expect($result)
         ->toBeArray()
-//        ->toHaveCount(5)
+        ->toHaveCount(5)
         ->toEqual([1, 2, 3, 1, 2]);
 });
 

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -603,3 +603,14 @@ it('tests copyWithin() method with all the parameters negative', function () {
         ->toHaveCount(5)
         ->toEqual([1, 2, 3, 3, 4]);
 });
+
+it('tests flatMap can handle an array of arrays', function () {
+    $arr = Arr::make([
+        [1, 2],
+        [3, 4]
+    ]);
+
+    $result = $arr->flatMap(fn ($element) => $element * 2);
+    expect($result->length())->toEqual(4);
+    expect($result->arr())->toEqual([2, 4, 6, 8]);
+});


### PR DESCRIPTION
This will allow users to use the `flatMap` method when they have multidimensional arrays.

Currently if the array contains other arrays then the method throws the following error:
```
 Unsupported operand types: array * int
```

This will now run the callback on the array element within the element and then flatten it.